### PR TITLE
Add "rollup-plugin-css-porter" so applib can deliver css too.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v1.1.0
+- New: CSS delivered via "applib.css" by way of "rollup-plugin-css-porter"
+
 ### v1.0.1
 - Fix: don't version build products
 - Chore: respect arguments passed to `npm run lint`

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build"
   ],
   "devDependencies": {
+    "rollup-plugin-css-porter": "0.1.2",
     "babel-plugin-external-helpers": "6.22.0",
     "babel-preset-env": "1.1.10",
     "babel-register": "6.23.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,11 @@
 import babel from 'rollup-plugin-babel'
 const pkg = require('./package.json')
+import css from 'rollup-plugin-css-porter'
 
 export default {
   entry: 'src/index.js',
   dest: pkg.main,
   format: 'cjs',
   sourceMap: true,
-  plugins: babel()
+  plugins: [ css({ minified: false }), babel() ]
 }


### PR DESCRIPTION
For instance, the "WidenImage.js" transform can then also have a "WidenImage.css" file and NPM will not only build "applib.js" but also "applib.css".

Respective iOS and Android "Gruntfile.js" will need be modified once to digest "node_modules/applib/build/applib.css" in platform appropriate way (to get "applib.css" into respective "assets" directories).